### PR TITLE
Set colors_name correctly

### DIFF
--- a/colors/codeschool.vim
+++ b/colors/codeschool.vim
@@ -9,7 +9,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Code School 3"
+let g:colors_name = "codeschool"
 
 hi Cursor ctermfg=16 ctermbg=145 cterm=NONE guifg=#182227 guibg=#9ea7a6 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#3f4b52 gui=NONE


### PR DESCRIPTION
`colors_name` is always set to the name of the colors file (see every other vim color scheme). It's not intended to serve as a _fancy display name_ kind of thing. The way it was before `vim` would complain on startup, at least when syntax highlighting was enabled.
